### PR TITLE
disease attribute retrieval from mesh and bert-based encoder

### DIFF
--- a/notebooks/01_01_disease_mesh_notes_retrieval.ipynb
+++ b/notebooks/01_01_disease_mesh_notes_retrieval.ipynb
@@ -1,0 +1,917 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = Path(\"/home/jovyan/BioBLP/data\")\n",
+    "biokg_disease_path = DATA_DIR.joinpath(\"raw/biokg.metadata.disease.tsv\")\n",
+    "mesh_scopenotes_path = DATA_DIR.joinpath(\"raw/meshid_scopenote.csv\")\n",
+    "mesh_scr_disease_notes_path = Path(\"./mesh_scr_disease_notes.tsv\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Contents\n",
+    "1. Inspect BioKG disease entities, and collect mesh identifiers\n",
+    "2. Use MeSH identifiers to retrieve textual descriptions/'notes corresponding to disease entity\n",
+    "    * a. retrieve textual `scopeNote` attributes by executing SPARRQL against MeSH rdf graph for entities of type rdfs:type DISEASE \n",
+    "    * b. retrieve textual `note` attributes by executing SPARRQL against MeSH rdf graph for entities of type rdfs:type SCR_DISEASE\n",
+    "          (SCR_DISEASE are additional to the regular MeSH DISEASE concepts, and are sourced from Supplementary Concept Diseases See https://www.nlm.nih.gov/bsd/indexing/training/CATC_053.html)\n",
+    "    * c. process results into useable form\n",
+    "3. Merge BioKG entities with their textual attributes\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Inspect BioKG disease entities, and collect mesh identifiers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SCR_DISEASE                                       6479\n",
+       "DISEASE                                           4868\n",
+       "Aural Atresia, Congenital                            1\n",
+       "Snowflake vitreoretinal degeneration                 1\n",
+       "Carnitine-Acylcarnitine Translocase Deficiency       1\n",
+       "                                                  ... \n",
+       "Severe Dengue                                        1\n",
+       "Neurodegenerative Diseases                           1\n",
+       "Uterine Inversion                                    1\n",
+       "Hepatitis, Autoimmune                                1\n",
+       "Hypobetalipoproteinemia, Familial, 1                 1\n",
+       "Name: entity, Length: 11349, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get biokg disease data\n",
+    "biokg_dis_df = pd.read_csv(biokg_disease_path, sep=\"\\t\", names=[\"mesh_id\", \"type\", \"entity\"], header=None)\n",
+    "biokg_dis_init_len = len(biokg_dis_df)\n",
+    "biokg_dis_counts = biokg_dis_df.entity.value_counts()\n",
+    "biokg_dis_counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the dataframe has several `rdfs:type` statements, where the entity either is of type DISEASE, or SCR_DISEASE.\n",
+    "This effectively duplicates the records against a certain MeSH identifier. We are only interested in the records which contain the actual entity nam label"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mesh ids are duplicated with extra rows coming from rdf type triples.\n",
+      "Total rows: 22694\n",
+      "# DISEASE type nodes: 4868 \n",
+      "# SCR_DISEASE nodes 6479\n",
+      "Biokg rows on dropping rdf type rows: 22694 --> 11347 \n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>entity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>11347</th>\n",
+       "      <td>D000006</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdomen, Acute</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11348</th>\n",
+       "      <td>D000007</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Injuries</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11349</th>\n",
+       "      <td>D000008</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Neoplasms</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11350</th>\n",
+       "      <td>D000012</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abetalipoproteinemia</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11351</th>\n",
+       "      <td>D000013</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Congenital Abnormalities</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       mesh_id  type                    entity\n",
+       "11347  D000006  NAME            Abdomen, Acute\n",
+       "11348  D000007  NAME        Abdominal Injuries\n",
+       "11349  D000008  NAME       Abdominal Neoplasms\n",
+       "11350  D000012  NAME      Abetalipoproteinemia\n",
+       "11351  D000013  NAME  Congenital Abnormalities"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(f\"mesh ids are duplicated with extra rows coming from rdf type triples.\\nTotal rows: {biokg_dis_init_len}\\n\"\\\n",
+    "f\"# DISEASE type nodes: {biokg_dis_counts['DISEASE']} \\n# SCR_DISEASE nodes {biokg_dis_counts['SCR_DISEASE']}\")\n",
+    "biokg_dis_df = biokg_dis_df[~biokg_dis_df[\"entity\"].isin([\"DISEASE\", \"SCR_DISEASE\"])]\n",
+    "print(f\"Biokg rows on dropping rdf type rows: {biokg_dis_init_len} --> {len(biokg_dis_df)} \")\n",
+    "biokg_dis_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# so we see that there are actually 11347 unique mesh concepts here, instead of 22K. The rest stem from duplicated entries citing provenance of source type, such as 'DISEASE', or \"SCR_DISEASE'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Use MeSH identifiers to retrieve textual descriptions/'notes corresponding to disease entity\n",
+    "#### 2a. retrieve textual `scopeNote` attributes by executing SPARRQL against MeSH rdf graph for entities of type rdfs:type DISEASE "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "29525\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>concept</th>\n",
+       "      <th>prefcon</th>\n",
+       "      <th>name</th>\n",
+       "      <th>scopeNote</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/D014525</td>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/M0022335</td>\n",
+       "      <td>Urethral Stricture</td>\n",
+       "      <td>Narrowing of any part of the URETHRA. It is ch...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/D017262</td>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/M0026201</td>\n",
+       "      <td>Siderophores</td>\n",
+       "      <td>Low-molecular-weight compounds produced by mic...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/D001321</td>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/M0001983</td>\n",
+       "      <td>Autistic Disorder</td>\n",
+       "      <td>A disorder beginning in childhood. It is marke...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/D015730</td>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/M0024115</td>\n",
+       "      <td>Djibouti</td>\n",
+       "      <td>A republic in eastern Africa, on the Gulf of A...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/D002330</td>\n",
+       "      <td>http://id.nlm.nih.gov/mesh/2020/M0003490</td>\n",
+       "      <td>Carmustine</td>\n",
+       "      <td>A cell-cycle phase nonspecific alkylating anti...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                   concept  \\\n",
+       "0  http://id.nlm.nih.gov/mesh/2020/D014525   \n",
+       "1  http://id.nlm.nih.gov/mesh/2020/D017262   \n",
+       "2  http://id.nlm.nih.gov/mesh/2020/D001321   \n",
+       "3  http://id.nlm.nih.gov/mesh/2020/D015730   \n",
+       "4  http://id.nlm.nih.gov/mesh/2020/D002330   \n",
+       "\n",
+       "                                    prefcon                name  \\\n",
+       "0  http://id.nlm.nih.gov/mesh/2020/M0022335  Urethral Stricture   \n",
+       "1  http://id.nlm.nih.gov/mesh/2020/M0026201        Siderophores   \n",
+       "2  http://id.nlm.nih.gov/mesh/2020/M0001983   Autistic Disorder   \n",
+       "3  http://id.nlm.nih.gov/mesh/2020/M0024115            Djibouti   \n",
+       "4  http://id.nlm.nih.gov/mesh/2020/M0003490          Carmustine   \n",
+       "\n",
+       "                                           scopeNote  \n",
+       "0  Narrowing of any part of the URETHRA. It is ch...  \n",
+       "1  Low-molecular-weight compounds produced by mic...  \n",
+       "2  A disorder beginning in childhood. It is marke...  \n",
+       "3  A republic in eastern Africa, on the Gulf of A...  \n",
+       "4  A cell-cycle phase nonspecific alkylating anti...  "
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Reusing mesh scopenotes for entities of type `DISEASE` from bioblp v0 work\n",
+    "mesh_notes_df = pd.read_csv(mesh_scopenotes_path, index_col=0)\n",
+    "print(len(mesh_notes_df))\n",
+    "mesh_notes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D014525</td>\n",
+       "      <td>Narrowing of any part of the URETHRA. It is ch...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D017262</td>\n",
+       "      <td>Low-molecular-weight compounds produced by mic...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mesh_id                                               note\n",
+       "0  D014525  Narrowing of any part of the URETHRA. It is ch...\n",
+       "1  D017262  Low-molecular-weight compounds produced by mic..."
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def parse_id_from_uri(uri: str):\n",
+    "    return uri.split(\"/\")[-1]\n",
+    "\n",
+    "mesh_notes_df[\"concept\"] = mesh_notes_df['concept'].apply(lambda x: parse_id_from_uri(x))\n",
+    "mesh_notes_df = mesh_notes_df[[\"concept\", \"scopeNote\"]]\n",
+    "mesh_notes_df = mesh_notes_df.rename(columns={\"concept\":\"mesh_id\", \"scopeNote\": \"note\"})\n",
+    "mesh_notes_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's merge biokg entities with the mesh notes using the mesh identifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>entity</th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D000006</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdomen, Acute</td>\n",
+       "      <td>A clinical syndrome with acute abdominal pain ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D000007</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Injuries</td>\n",
+       "      <td>General or unspecified injuries involving orga...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mesh_id  type              entity  \\\n",
+       "0  D000006  NAME      Abdomen, Acute   \n",
+       "1  D000007  NAME  Abdominal Injuries   \n",
+       "\n",
+       "                                                note  \n",
+       "0  A clinical syndrome with acute abdominal pain ...  \n",
+       "1  General or unspecified injuries involving orga...  "
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "biokg_mesh_disease_df = biokg_dis_df.merge(mesh_notes_df, how=\"inner\", left_on=\"mesh_id\", right_on=\"mesh_id\")\n",
+    "biokg_mesh_disease_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of biokg entities for which scope notes or mesh ids were found 11347 -> 4868\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Number of biokg entities for which scope notes or mesh ids were found {len(biokg_dis_df)} -> {len(biokg_mesh_disease_df)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We seem to be losing several entities. This is because we are losing all the SCR_DISEASE nodes during the inner merge. \n",
+    "The textual properties for nodes of type SCR_DISEASE are hidden under different properties, namely meshv:note, instead of meshv:scopeNote\n",
+    "We'll retrieve these separately"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###   2b. retrieve textual `note` attributes by executing SPARRQL against MeSH rdf graph for entities of type rdfs:type SCR_DISEASE\n",
+    "\n",
+    "(SCR_DISEASE are additional to the regular MeSH DISEASE concepts, and are sourced from Supplementary Concept Diseases See https://www.nlm.nih.gov/bsd/indexing/training/CATC_053.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from SPARQLWrapper import SPARQLWrapper, JSON\n",
+    "\n",
+    "# Specify the DBPedia endpoint\n",
+    "sparql = SPARQLWrapper(\"http://id.nlm.nih.gov/mesh/sparql\")\n",
+    "\n",
+    "\n",
+    "sparql.setReturnFormat('n3')\n",
+    "# Query for the description of \"Capsaicin\", filtered by language\n",
+    "sparql.setQuery(\"\"\"\n",
+    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+    "PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>\n",
+    "PREFIX mesh: <http://id.nlm.nih.gov/mesh/>\n",
+    "CONSTRUCT {?s meshv:note ?note.\n",
+    "         }\n",
+    "FROM <http://id.nlm.nih.gov/mesh>\n",
+    "\n",
+    "WHERE {\n",
+    "  ?s a meshv:SCR_Disease.\n",
+    "  ?s meshv:note ?note.\n",
+    "\n",
+    "\n",
+    "     }\n",
+    "\"\"\")\n",
+    "\n",
+    "results = sparql.queryAndConvert()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['<http://id.nlm.nih.gov/mesh/C538525>\\n        <http://id.nlm.nih.gov/mesh/vocab#note>\\n                \"Mitochondrial myopathy encephalopathy lactic acidosis and strokelike episodes\"@en .',\n",
+       " '<http://id.nlm.nih.gov/mesh/C563160>\\n        <http://id.nlm.nih.gov/mesh/vocab#note>\\n                \"A rare hereditary autosomal dominant condition that affects multiple parts of the body; particularly the face, eyes, teeth, and extremities. Affected individuals often have small eyes (MICROPHTHALMIA), small or missing teeth, weak enamel, multiple cavities, and early tooth loss. Other common features include a thin nose and SYNDACTYLY between the fourth and fifth fingers. HYPOTRICHOSIS, syndactyly of the toes, curvature of fingers, MICROCEPHALY, and CLEFT PALATE may also occur but are less common. Some patients may also experience ATAXIA, MUSCLE SPASTICITY, hearing loss, and speech difficulties. Mutations in the GJA1 gene have been identified. OMIM: 164200\"@en .',\n",
+       " '<http://id.nlm.nih.gov/mesh/C535998>\\n        <http://id.nlm.nih.gov/mesh/vocab#note>\\n                \"A milk-filled retention cyst beneath the areola that may occur in young women who are pregnant or breast feeding following the cessation of lactation. It may mimic tumors on imaging.\"@en .',\n",
+       " '<http://id.nlm.nih.gov/mesh/C548085>\\n        <http://id.nlm.nih.gov/mesh/vocab#note>\\n                \"Replaced \\\\\"Progressive Transformation Of Germinal Centers\\\\\" with \\\\\"Progressive Transformation of Germinal Centers\\\\\".\"@en .',\n",
+       " '<http://id.nlm.nih.gov/mesh/C537710>\\n        <http://id.nlm.nih.gov/mesh/vocab#note>\\n                \"An autosomal dominant disorder that presents as lymphedema of the limbs and double rows of eyelashes (distichiasis). Irritation of the CORNEA, with corneal ulceration in some cases, brings the patients to the attention of ophthalmologists. Other complications may include cardiac defects, VARICOSE VEINS, ptosis, spinal extradural cysts, and PHOTOPHOBIA. Mutations in the FOXC2 gene have been identified. OMIM: 153400\"@en .']"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "record_list = results.decode('utf-8').split(\"\\n\\n\")\n",
+    "record_list[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['<http://id.nlm.nih.gov/mesh/C538525>',\n",
+       "  '        <http://id.nlm.nih.gov/mesh/vocab#note>',\n",
+       "  '                \"Mitochondrial myopathy encephalopathy lactic acidosis and strokelike episodes\"@en .'],\n",
+       " ['<http://id.nlm.nih.gov/mesh/C563160>',\n",
+       "  '        <http://id.nlm.nih.gov/mesh/vocab#note>',\n",
+       "  '                \"A rare hereditary autosomal dominant condition that affects multiple parts of the body; particularly the face, eyes, teeth, and extremities. Affected individuals often have small eyes (MICROPHTHALMIA), small or missing teeth, weak enamel, multiple cavities, and early tooth loss. Other common features include a thin nose and SYNDACTYLY between the fourth and fifth fingers. HYPOTRICHOSIS, syndactyly of the toes, curvature of fingers, MICROCEPHALY, and CLEFT PALATE may also occur but are less common. Some patients may also experience ATAXIA, MUSCLE SPASTICITY, hearing loss, and speech difficulties. Mutations in the GJA1 gene have been identified. OMIM: 164200\"@en .'],\n",
+       " ['<http://id.nlm.nih.gov/mesh/C535998>',\n",
+       "  '        <http://id.nlm.nih.gov/mesh/vocab#note>',\n",
+       "  '                \"A milk-filled retention cyst beneath the areola that may occur in young women who are pregnant or breast feeding following the cessation of lactation. It may mimic tumors on imaging.\"@en .']]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "record_list_nested = [record.split('\\n') for record in record_list]\n",
+    "\n",
+    "record_list_nested[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(2092, 2)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;http://id.nlm.nih.gov/mesh/C538525&gt;</td>\n",
+       "      <td>\"Mitochondrial myopathy enceph...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;http://id.nlm.nih.gov/mesh/C563160&gt;</td>\n",
+       "      <td>\"A rare hereditary autosomal d...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                mesh_id  \\\n",
+       "0  <http://id.nlm.nih.gov/mesh/C538525>   \n",
+       "1  <http://id.nlm.nih.gov/mesh/C563160>   \n",
+       "\n",
+       "                                                note  \n",
+       "0                  \"Mitochondrial myopathy enceph...  \n",
+       "1                  \"A rare hereditary autosomal d...  "
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mesh_scr_notes_df = pd.DataFrame(record_list_nested, columns=[\"mesh_id\", \"predicate\", \"note\", \"tag\"])\n",
+    "mesh_scr_notes_df = mesh_scr_notes_df[[\"mesh_id\", \"note\"]]\n",
+    "print(mesh_scr_notes_df.shape)\n",
+    "mesh_scr_notes_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>C538525</td>\n",
+       "      <td>\"Mitochondrial myopathy enceph...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>C563160</td>\n",
+       "      <td>\"A rare hereditary autosomal d...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C535998</td>\n",
+       "      <td>\"A milk-filled retention cyst ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>C548085</td>\n",
+       "      <td>\"Replaced \\\"Progressive Transf...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>C537710</td>\n",
+       "      <td>\"An autosomal dominant disorde...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mesh_id                                               note\n",
+       "0  C538525                  \"Mitochondrial myopathy enceph...\n",
+       "1  C563160                  \"A rare hereditary autosomal d...\n",
+       "2  C535998                  \"A milk-filled retention cyst ...\n",
+       "3  C548085                  \"Replaced \\\"Progressive Transf...\n",
+       "4  C537710                  \"An autosomal dominant disorde..."
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def parse_id_from_uri_rdf(uri: str):\n",
+    "    return uri.rstrip(\">\").split(\"/\")[-1]\n",
+    "\n",
+    "mesh_scr_notes_df[\"mesh_id\"] = mesh_scr_notes_df[\"mesh_id\"].apply(lambda x: parse_id_from_uri_rdf(x))\n",
+    "mesh_scr_notes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_scr_notes_df.mesh_id.nunique()\n",
+    "mesh_scr_notes_df.to_csv(\"mesh_scr_disease_notes.tsv\", sep=\"\\t\", header=True, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Merge Biokg with DISEASE, SCR_DISEASE data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LOAD_MESH_SCR_NOTES_FROM_DISK = False\n",
+    "if LOAD_MESH_SCR_NOTES_FROM_DISK:\n",
+    "    mesh_scr_notes_df = pd.read_csv(mesh_scr_disease_notes_path, delimiter=\"\\t\", header=0, index_col=None)\n",
+    "    mesh_scr_notes_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_notes_df_merged = pd.concat([mesh_notes_df, mesh_scr_notes_df], axis=0)\n",
+    "mesh_notes_df_merged.to_csv(\"mesh_disease_notes_merged.tsv\", sep=\"\\t\", header=True, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(6865, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>entity</th>\n",
+       "      <th>note_x</th>\n",
+       "      <th>note_y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D000006</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdomen, Acute</td>\n",
+       "      <td>A clinical syndrome with acute abdominal pain ...</td>\n",
+       "      <td>A clinical syndrome with acute abdominal pain ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D000007</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Injuries</td>\n",
+       "      <td>General or unspecified injuries involving orga...</td>\n",
+       "      <td>General or unspecified injuries involving orga...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mesh_id  type              entity  \\\n",
+       "0  D000006  NAME      Abdomen, Acute   \n",
+       "1  D000007  NAME  Abdominal Injuries   \n",
+       "\n",
+       "                                              note_x  \\\n",
+       "0  A clinical syndrome with acute abdominal pain ...   \n",
+       "1  General or unspecified injuries involving orga...   \n",
+       "\n",
+       "                                              note_y  \n",
+       "0  A clinical syndrome with acute abdominal pain ...  \n",
+       "1  General or unspecified injuries involving orga...  "
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "biokg_dis_df = biokg_dis_df.merge(mesh_notes_df_merged, how=\"inner\", left_on=\"mesh_id\", right_on=\"mesh_id\")\n",
+    "print(biokg_dis_df.shape)\n",
+    "biokg_dis_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".conda-bioblp-env [Python]",
+   "language": "python",
+   "name": "conda-env-.conda-bioblp-env-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/01_02_disease_bert_encodings.ipynb
+++ b/notebooks/01_02_disease_bert_encodings.ipynb
@@ -1,0 +1,563 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import datetime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = Path(\"/home/jovyan/BioBLP/data\")\n",
+    "#DISEASE_ATTR_DATA_DIR = DATA_DIR.joinpath(\"raw/disease_attributes\")\n",
+    "DISEASE_ATTR_DATA_DIR=Path(\".\")\n",
+    "biokg_disease_path = DATA_DIR.joinpath(\"raw/biokg.metadata.disease.tsv\")\n",
+    "mesh_disease_notes_merged_path = DISEASE_ATTR_DATA_DIR.joinpath(\"mesh_disease_notes_merged.tsv\")\n",
+    "biokg_mesh_df_path = DISEASE_ATTR_DATA_DIR.joinpath(\"biokg_w_dis_mesh_notes.tsv\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve disease textual properties for biokg entities\n",
+    "Precurser notebook can be located at `./disease_mesh_notes_retrieval.ipynb`, which contains data inspection, retrieving MeSH textual notes using SPARQL queries against MeSH query endpoint, as well as postprocessing and serialising to disk.\n",
+    "The dataframe stored at above mentioned path `mesh_disease_notes_merged_path` is a product of the above notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "31617\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>D014525</th>\n",
+       "      <td>Narrowing of any part of the URETHRA. It is ch...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>D017262</th>\n",
+       "      <td>Low-molecular-weight compounds produced by mic...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>D001321</th>\n",
+       "      <td>A disorder beginning in childhood. It is marke...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>D015730</th>\n",
+       "      <td>A republic in eastern Africa, on the Gulf of A...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>D002330</th>\n",
+       "      <td>A cell-cycle phase nonspecific alkylating anti...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                      note\n",
+       "mesh_id                                                   \n",
+       "D014525  Narrowing of any part of the URETHRA. It is ch...\n",
+       "D017262  Low-molecular-weight compounds produced by mic...\n",
+       "D001321  A disorder beginning in childhood. It is marke...\n",
+       "D015730  A republic in eastern Africa, on the Gulf of A...\n",
+       "D002330  A cell-cycle phase nonspecific alkylating anti..."
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mesh_notes_merged_df = pd.read_csv(mesh_disease_notes_merged_path, index_col=0, sep=\"\\t\")\n",
+    "print(len(mesh_notes_merged_df))\n",
+    "mesh_notes_merged_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mesh ids are duplicated with extra rows coming from rdf type triples.\n",
+      "Total rows: 22694\n",
+      "# DISEASE type nodes: 4868 \n",
+      "# SCR_DISEASE nodes 6479\n",
+      "Biokg rows on dropping rdf type rows: 22694 --> 11347 \n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>entity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>11347</th>\n",
+       "      <td>D000006</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdomen, Acute</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11348</th>\n",
+       "      <td>D000007</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Injuries</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11349</th>\n",
+       "      <td>D000008</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Neoplasms</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11350</th>\n",
+       "      <td>D000012</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abetalipoproteinemia</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11351</th>\n",
+       "      <td>D000013</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Congenital Abnormalities</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       mesh_id  type                    entity\n",
+       "11347  D000006  NAME            Abdomen, Acute\n",
+       "11348  D000007  NAME        Abdominal Injuries\n",
+       "11349  D000008  NAME       Abdominal Neoplasms\n",
+       "11350  D000012  NAME      Abetalipoproteinemia\n",
+       "11351  D000013  NAME  Congenital Abnormalities"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get biokg disease data\n",
+    "biokg_dis_df = pd.read_csv(biokg_disease_path, sep=\"\\t\", names=[\"mesh_id\", \"type\", \"entity\"], header=None)\n",
+    "biokg_dis_init_len = len(biokg_dis_df)\n",
+    "biokg_dis_counts = biokg_dis_df.entity.value_counts()\n",
+    "print(f\"mesh ids are duplicated with extra rows coming from rdf type triples.\\nTotal rows: {biokg_dis_init_len}\\n\"\\\n",
+    "f\"# DISEASE type nodes: {biokg_dis_counts['DISEASE']} \\n# SCR_DISEASE nodes {biokg_dis_counts['SCR_DISEASE']}\")\n",
+    "biokg_dis_df = biokg_dis_df[~biokg_dis_df[\"entity\"].isin([\"DISEASE\", \"SCR_DISEASE\"])]\n",
+    "print(f\"Biokg rows on dropping rdf type rows: {biokg_dis_init_len} --> {len(biokg_dis_df)} \")\n",
+    "\n",
+    "biokg_dis_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Merge mesh and biokg dfs on id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(6865, 4)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mesh_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>entity</th>\n",
+       "      <th>note</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D000006</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdomen, Acute</td>\n",
+       "      <td>A clinical syndrome with acute abdominal pain ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D000007</td>\n",
+       "      <td>NAME</td>\n",
+       "      <td>Abdominal Injuries</td>\n",
+       "      <td>General or unspecified injuries involving orga...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mesh_id  type              entity  \\\n",
+       "0  D000006  NAME      Abdomen, Acute   \n",
+       "1  D000007  NAME  Abdominal Injuries   \n",
+       "\n",
+       "                                                note  \n",
+       "0  A clinical syndrome with acute abdominal pain ...  \n",
+       "1  General or unspecified injuries involving orga...  "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "biokg_dis_df = biokg_dis_df.merge(mesh_notes_merged_df, how=\"inner\", left_on=\"mesh_id\", right_on=\"mesh_id\")\n",
+    "print(biokg_dis_df.shape)\n",
+    "biokg_dis_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WRITE_TO_DISK = False\n",
+    "if WRITE_TO_DISK:\n",
+    "    biokg_dis_df.to_csv(biokg_mesh_df_path, sep=\"\\t\", header=True, index=False)\n",
+    "else:\n",
+    "    biokg_dis_df = pd.read_csv(biokg_mesh_df_path, delimiter=\"\\t\", header=0, index_col=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get BERT-base embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.nn import CrossEntropyLoss\n",
+    "\n",
+    "from transformers import BertModel, BertPreTrainedModel\n",
+    "from transformers import BertTokenizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of the model checkpoint at bert-base-cased were not used when initializing BertModel: ['cls.seq_relationship.weight', 'cls.predictions.decoder.weight', 'cls.predictions.transform.dense.bias', 'cls.seq_relationship.bias', 'cls.predictions.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.LayerNorm.bias', 'cls.predictions.transform.LayerNorm.weight']\n",
+      "- This IS expected if you are initializing BertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing BertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the \"bert-base-cased\" pretrained model, and corresponding tokenizer\n",
+    "tz = BertTokenizer.from_pretrained('bert-base-cased')\n",
+    "model = BertModel.from_pretrained(\"bert-base-cased\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'input_ids': tensor([[  101,   138,  7300,  9318,  1114, 12104, 24716,  2489,  1115,  1110,\n",
+       "          5199,   117, 25813,   117,  1105,  6099,  1107, 15415,   119,   138,\n",
+       "         23987, 14701,  1336,  1129,  2416,  1118,   170,  2783,  1104, 11759,\n",
+       "           117,  5917,   117,  1137,  8131,   119,   102]]), 'token_type_ids': tensor([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+       "         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]), 'attention_mask': tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
+       "         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Inspect an example\n",
+    "i = 0\n",
+    "sample_sent = biokg_dis_df.iloc[i]['note']\n",
+    "sentences = biokg_dis_df.note.to_list()[:3]\n",
+    "tz(sample_sent, padding=True, return_tensors=\"pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6865"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "disease_id_note_pairs = list(biokg_dis_df[['mesh_id', 'note']].to_records(index=False))\n",
+    "len(disease_id_note_pairs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encodings_out_path = Path('./disease_encodings/disease_embeddings.npz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 6865/6865 [11:33<00:00,  9.90it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tqdm import tqdm\n",
+    "mesh_ids = []\n",
+    "embeddings = []\n",
+    "\n",
+    "for mesh_id, note in tqdm(disease_id_note_pairs):\n",
+    "    mesh_ids.append(mesh_id)\n",
+    "    encoded = tz(note, padding=True, return_tensors=\"pt\")\n",
+    "    outputs = model(**encoded)\n",
+    "    embedding = outputs[0][0][0].detach().numpy()\n",
+    "    embeddings.append(embedding)\n",
+    "    #print(f\"{mesh_id} with embedding of shape {embedding.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved embeddings to disease_encodings/disease_embeddings.npz\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_dict = {mesh_id: emb for mesh_id, emb in zip(mesh_ids, embeddings)}\n",
+    "np.savez(encodings_out_path, **out_dict)\n",
+    "print(\"Saved embeddings to\", encodings_out_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['D000006', 'D000007', 'D000008', 'D000012', 'D000013']"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "x = np.load(encodings_out_path)\n",
+    "list(x.keys())[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = list(x.values())[1]\n",
+    "torch.from_numpy(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get data in one place snd sgare\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".conda-bioblp-env [Python]",
+   "language": "python",
+   "name": "conda-env-.conda-bioblp-env-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Includes notebooks for retrieving and encoding Disease entity node attributes:

* [01_01_disease_mesh_notes_retrieval.ipynb](https://github.com/elsevier-AI-Lab/BioBLP/compare/main...disease_attribute_encode#diff-b154c051c355439cc694117626b1d741b57fc8ab8b1948b300d14846d461769e): Retrieves textual scope notes (descriptions) for disease entities in BioKG graph using MeSH identifiers. Scope notes retrieved by querying against MeSH SPARQL end point.
* [notebooks/01_02_disease_bert_encodings.ipynb](https://github.com/elsevier-AI-Lab/BioBLP/compare/main...disease_attribute_encode#diff-0e9c53df1bb74ccf9d424bcb768625034307152f2b5347bfca42dd1e2b7b1363) Uses a pretrained BioBERT model to encode the disease entities using their MeSH textual scope notes as input.