### PR TITLE
Fix w&b ID not being retrieved correctly

### DIFF
--- a/bioblp/train.py
+++ b/bioblp/train.py
@@ -39,8 +39,8 @@ class WBIDCallback(TrainingCallback):
     We use it to get a file name for the stored model."""
     id = None
 
-    def post_train(self, *args, **kwargs):
-        if wandb.run is not None:
+    def post_epoch(self, *args, **kwargs):
+        if wandb.run is not None and WBIDCallback.id is None:
             WBIDCallback.id = wandb.run.id
 
 


### PR DESCRIPTION
The ID of the run in weights and biases is used to save trained models. However, W&B is initialized and run internally in PyKEEN's pipeline, so it's not trivial to get the ID.

Getting the ID was implemented first using a [callback](https://pykeen.readthedocs.io/en/stable/api/pykeen.training.callbacks.TrainingCallback.html), via the `post_train` method. It turns out that it can happen that when `post_train` is called, W&B has already been closed so there is no ID. The fix is to use `post_epoch` instead.