### PR TITLE
Add layer to reduce dimension of embeddings

### DIFF
--- a/bioblp/utils/bioblp_utils.py
+++ b/bioblp/utils/bioblp_utils.py
@@ -16,7 +16,8 @@ def build_encoders(dim: int,
 
     if protein_data:
         protein_encoder = encoders.PretrainedLookupTableEncoder(
-            file_path=protein_data
+            file_path=protein_data,
+            dim=dim
         )
         encoders_list.append(protein_encoder)
 


### PR DESCRIPTION
A small modification in `PretrainedLookupTableEncoder` that adds a layer for reducing the dimension of any input embedding to a specified output embedding size.