### PR TITLE
Fix .gitignore so that bioblp.py is included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,13 +133,10 @@ data/
 
 # Generated artifacts
 wandb/
-models/
+/models
 
 # Editor
 .vscode
 
 # PyCharm
 .idea
-# local data
-data/
-models/

--- a/bioblp/models/bioblp.py
+++ b/bioblp/models/bioblp.py
@@ -1,0 +1,14 @@
+from pykeen.models import ERModel
+from pykeen.nn.modules import ComplExInteraction
+
+from bioblp.models.encoders import PropertyEncoderRepresentation
+
+
+class BioBLP(ERModel):
+    def __init__(self, *, entity_representations: PropertyEncoderRepresentation,
+                 embedding_dim, regularizer, **kwargs):
+
+        super().__init__(interaction=ComplExInteraction(),
+                         entity_representations=entity_representations,
+                         relation_representations_kwargs={'shape': entity_representations.shape},
+                         **kwargs)


### PR DESCRIPTION
A rule in .gitignore was preventing from tracking `bioblp/models/bioblp.py`. I've modified the rule to include this file.